### PR TITLE
TOP-117: keep values in `Type` column remaining in English to unify …

### DIFF
--- a/source/spot/cn/index.html.md
+++ b/source/spot/cn/index.html.md
@@ -1619,7 +1619,7 @@ BTSE的速率限制如下:
 | 名称  | 类型        | 是否必须    | 描述                 |
 | ---   | ---         | ---      | ---                 |
 | topic | string      | Yes      | WebSocket 主题       |
-| data  | 数据对象    | Yes      | 详细数据，请参考下方数据对象 |
+| data  | Data Object    | Yes      | 详细数据，请参考下方数据对象 |
 
 #### 数据对象
 
@@ -1751,7 +1751,7 @@ BTSE的速率限制如下:
 | 名称  | 类型        | 是否必须    | 描述                 |
 | ---   | ---         | ---      | ---                 |
 | topic | string      | Yes      | WebSocket 主题       |
-| data  | 数据对象    | Yes      | 详细数据，请参考下方数据对象 |
+| data  | Data Object    | Yes      | 详细数据，请参考下方数据对象 |
 
 #### 数据对象
 


### PR DESCRIPTION
…the format through the pages

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->