### PR TITLE
Update description & examples for notification & tradeHistory topic

### DIFF
--- a/source/futuresV2_2/cn/index.html.md
+++ b/source/futuresV2_2/cn/index.html.md
@@ -2951,7 +2951,7 @@ pong
 }
 ```
 
-订阅市场的最近交易提要。主题将是 `tradeHistoryApi:<market>`，其中`<market>` 是市场符号。
+订阅市场的最近交易提要。主题将是 `tradeHistoryApiV2:<market>`，其中`<market>` 是市场符号。
 
 ### 响应内容
 
@@ -3037,7 +3037,7 @@ echo -n "/ws/futures1624985375123"  | openssl dgst -sha384 -hmac "848db84ac252b6
   "topic": "notificationApiV3",
   "data": [
     {
-      "symbol": "Market Symbol (eg. BTC-PERP)",
+      "symbol": "Market Symbol (eg. BTC-PERP, for topic \"notificationApiV2\" will be BTCPFC)",
       "orderID": "BTSE internal order ID",
       "side": "BUY",
       "type": "76",
@@ -3064,7 +3064,8 @@ echo -n "/ws/futures1624985375123"  | openssl dgst -sha384 -hmac "848db84ac252b6
 
 ```
 
-接收交易通知通过订阅主题 `notificationApiV2`。Websocket将向订阅者推送交易级别的通知。如果在未经认证的情况下订阅主题，将不会发送任何消息。
+接收交易通知，请订阅 `notificationApiV2`或 `notificationApiV3` 主题。建议使用 `notificationApiV3`，它以更直观的格式提供市场符号，例如 BTC-PERP。
+WebSocket 将向已认证的订阅者推送实时交易级别的通知。Websocket将向订阅者推送交易级别的通知。如果在未经认证的情况下订阅主题，将不会发送任何消息。
 
 ### 响应内容
 

--- a/source/futuresV2_2/en/index.html.md
+++ b/source/futuresV2_2/en/index.html.md
@@ -2953,7 +2953,7 @@ To subscribe to a websocket public trade fill
 }
 ```
 
-Subscribe to recent trade feed for a market. The topic will be `tradeHistoryApi:<market>` where `<market>` is the market symbol.
+Subscribe to recent trade feed for a market. The topic will be `tradeHistoryApiV2:<market>` where `<market>` is the market symbol.
 
 ### Response Content
 
@@ -3039,7 +3039,7 @@ echo -n "/ws/futures1624985375123"  | openssl dgst -sha384 -hmac "848db84ac252b6
   "topic": "notificationApiV3",
   "data": [
     {
-      "symbol": "Market Symbol (eg. BTC-PERP)",
+      "symbol": "Market Symbol (eg. BTC-PERP, for topic \"notificationApiV2\" will be BTCPFC)",
       "orderID": "BTSE internal order ID",
       "side": "BUY",
       "type": "76",
@@ -3066,7 +3066,8 @@ echo -n "/ws/futures1624985375123"  | openssl dgst -sha384 -hmac "848db84ac252b6
 
 ```
 
-Receive trade notifications by subscribing to the topic `notificationApiV2`. The websocket feed will push trade level notifications to the subscriber. If topic is subscribed without being authenticated, no messages will be sent.
+To receive trade notifications, subscribe to the `notificationApiV2` or `notificationApiV3` topics. It is recommended to use `notificationApiV3`, which provides market symbols in a more intuitive format, such as BTC-PERP. The WebSocket feed will push real-time, trade-level notifications to authenticated subscribers.
+Please note, if the topic is subscribed to without proper authentication, no messages will be delivered.
 
 ### Response Content
 


### PR DESCRIPTION
- Update description for "notificationApiV3" to better indicate the differences of symbol value between notificationApiV2, eg. BTCPFC vs BTC-PERP
- Align description and example for topic "tradeHistoryApiV2"

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->