### PR TITLE
Remove grouping description for OSS

### DIFF
--- a/source/futures/cn/index.html.md
+++ b/source/futures/cn/index.html.md
@@ -2910,7 +2910,7 @@ BTSE 的速率限制如下：
   * 测试网络
     * `wss://testws.btse.io/ws/oss/futures`
 
-## OSS L1 快照 (按分组)
+## OSS L1 快照
 
 > 请求
 
@@ -2918,14 +2918,14 @@ BTSE 的速率限制如下：
 {
   "op": "subscribe",
   "args": [
-    "snapshotL1:BTCPFC_0"
+    "snapshotL1:BTCPFC"
   ]
 }
 
 {
   "op": "unsubscribe",
   "args": [
-    "snapshotL1:BTCPFC_0"
+    "snapshotL1:BTCPFC"
   ]
 }
 ```
@@ -2934,7 +2934,7 @@ BTSE 的速率限制如下：
 
 ```json
 {
-  "topic": "snapshotL1:BTCPFC_0",
+  "topic": "snapshotL1:BTCPFC",
   "data": {
     "bids": [
       [
@@ -2955,10 +2955,9 @@ BTSE 的速率限制如下：
 }
 ```
 
-通过端点`wss://ws.btse.com/ws/oss/futures`订阅Level 1订单簿。订阅的格式将为`symbol_grouping`。
+通过端点`wss://ws.btse.com/ws/oss/futures`订阅Level 1订单簿。订阅的格式将为`symbol`。
 
 * `symbol`表示市场符号
-* `grouping`表示分组的粒度。有效值为0-8。
 
 ### 响应内容
 

--- a/source/futures/en/index.html.md
+++ b/source/futures/en/index.html.md
@@ -2914,7 +2914,7 @@ Transfers funds between user and sub-account wallet. User can specify the source
   * Testnet
     * `wss://testws.btse.io/ws/oss/futures`
 
-## OSS L1 Snapshot (By grouping)
+## OSS L1 Snapshot
 
 > Request
 
@@ -2922,14 +2922,14 @@ Transfers funds between user and sub-account wallet. User can specify the source
 {
   "op": "subscribe",
   "args": [
-    "snapshotL1:BTCPFC_0"
+    "snapshotL1:BTCPFC"
   ]
 }
 
 {
   "op": "unsubscribe",
   "args": [
-    "snapshotL1:BTCPFC_0"
+    "snapshotL1:BTCPFC"
   ]
 }
 ```
@@ -2938,7 +2938,7 @@ Transfers funds between user and sub-account wallet. User can specify the source
 
 ```json
 {
-  "topic": "snapshotL1:BTCPFC_0",
+  "topic": "snapshotL1:BTCPFC",
   "data": {
     "bids": [
       [
@@ -2959,10 +2959,9 @@ Transfers funds between user and sub-account wallet. User can specify the source
 }
 ```
 
-Subscribe to the Level 1 Orderbook through the endpoint `wss://ws.btse.com/ws/oss/futures`. The format to subscribe to will be `symbol_grouping`.
+Subscribe to the Level 1 Orderbook through the endpoint `wss://ws.btse.com/ws/oss/futures`. The format to subscribe to will be `symbol`.
 
 * `symbol` indicates the market symbol
-* `grouping` indicates the grouping granularity. Valid values are 0-8.
 
 ### Response Content
 

--- a/source/spot/cn/index.html.md
+++ b/source/spot/cn/index.html.md
@@ -1704,7 +1704,7 @@ BTSE的速率限制如下:
   * 测试网络
      * `wss://testws.btse.io/ws/oss/spot`
 
-## OSS L1 快照（按分组）
+## OSS L1 快照
 
 > 请求
 
@@ -1712,14 +1712,14 @@ BTSE的速率限制如下:
 {
   "op": "subscribe",
   "args": [
-    "snapshotL1:BTC-USD_0"
+    "snapshotL1:BTC-USD"
   ]
 }
 
 {
   "op": "unsubscribe",
   "args": [
-    "snapshotL1:BTC-USD_0"
+    "snapshotL1:BTC-USD"
   ]
 }
 ```
@@ -1728,7 +1728,7 @@ BTSE的速率限制如下:
 
 ```json
 {
-  "topic": "snapshotL1:BTC-USD_0",
+  "topic": "snapshotL1:BTC-USD",
   "data": {
     "bids": [
       [
@@ -1749,10 +1749,9 @@ BTSE的速率限制如下:
 }
 ```
 
-通过端点 `wss://ws.btse.com/ws/oss/spot` 订阅Level 1订单簿。订阅的格式将为 `symbol_grouping`。
+通过端点 `wss://ws.btse.com/ws/oss/spot` 订阅Level 1订单簿。订阅的格式将为 `symbol`。
 
 * `symbol` 表示市场符号
-* `grouping` 表示分组粒度。有效值为0-8。
 
 ### 响应内容
 

--- a/source/spot/en/index.html.md
+++ b/source/spot/en/index.html.md
@@ -1717,7 +1717,7 @@ Query investment history. Requires `Wallet` permission.
   * Testnet
      * `wss://testws.btse.io/ws/oss/spot`
 
-## OSS L1 Snapshot (By grouping)
+## OSS L1 Snapshot
 
 > Request
 
@@ -1725,14 +1725,14 @@ Query investment history. Requires `Wallet` permission.
 {
   "op": "subscribe",
   "args": [
-    "snapshotL1:BTC-USD_0"
+    "snapshotL1:BTC-USD"
   ]
 }
 
 {
   "op": "unsubscribe",
   "args": [
-    "snapshotL1:BTC-USD_0"
+    "snapshotL1:BTC-USD"
   ]
 }
 ```
@@ -1741,7 +1741,7 @@ Query investment history. Requires `Wallet` permission.
 
 ```json
 {
-  "topic": "snapshotL1:BTC-USD_0",
+  "topic": "snapshotL1:BTC-USD",
   "data": {
     "bids": [
       [
@@ -1762,10 +1762,9 @@ Query investment history. Requires `Wallet` permission.
 }
 ```
 
-Subscribe to the Level 1 Orderbook through the endpoint `wss://ws.btse.com/ws/oss/spot`. The format to subscribe to will be `symbol_grouping`.
+Subscribe to the Level 1 Orderbook through the endpoint `wss://ws.btse.com/ws/oss/spot`. The format to subscribe to will be `symbol`.
 
 * `symbol` indicates the market symbol
-* `grouping` indicates the grouping granularity. Valid values are 0-8.
 
 ### Response Content
 


### PR DESCRIPTION
Remove grouping details from OSS L1 Snapshot

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->